### PR TITLE
Setup possibility to fetch screenings from frontend

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 import express from "express";
 import { engine } from "express-handlebars";
-import { getMovie, getMovies } from "./movies.js";
+import { getMovie, getMovies, getMovieScreenings } from "./movies.js";
 import { marked } from "marked";
 
 const app = express();
@@ -39,6 +39,11 @@ app.get("/movies/:movieId", async (request, response) => {
   const movie = await getMovie(request.params.movieId);
   movie.intro = marked(movie.intro);
   renderPage(response, "movie", { movie });
+});
+
+app.get("/api/movies/:id/screenings", async (req, res) => {
+  const movieScreenings = await getMovieScreenings(req.params.id);
+  res.json(movieScreenings);
 });
 
 app.get("/aboutus", async (request, response) => {

--- a/src/movies.js
+++ b/src/movies.js
@@ -22,3 +22,12 @@ export async function getMovie(id) {
     ...payload.data.attributes,
   };
 }
+
+export async function getMovieScreenings(id) {
+  const res = await fetch(`${API_BASE}/screenings?filters[movie]=${id}`);
+  const payload = await res.json();
+  return payload.data.map((screening) => ({
+    id: screening.id,
+    ...screening.attributes,
+  }));
+}

--- a/static/individualScreenings.js
+++ b/static/individualScreenings.js
@@ -1,0 +1,10 @@
+const currentPath = window.location.pathname;
+
+fetch("/api" + currentPath + "/screenings")
+  .then((response) => response.json())
+  .then((movieScreenings) => {
+    movieScreenings.forEach((screening) => {
+      console.log("Start time:", screening.start_time);
+      console.log("Theater:", screening.room);
+    });
+  });

--- a/templates/movie.handlebars
+++ b/templates/movie.handlebars
@@ -1,3 +1,4 @@
+<script src="/static/individualScreenings.js" type="module" defer></script>
 <section class="movieInformation">
   <div class="movieInformation__container">
     {{#if movie.image}}


### PR DESCRIPTION
Me and William did the initial work to communicate with Richard's API. We set up a route to fetch movie screenings data based on the current movie page. This includes a new getMovieScreenings function that fetches and formats the data from the API, and a new route handler for '/api/movies/:id/screenings'. We also added a fetch call on the frontend to retrieve and log the data for the current movie's screenings. At this moment, the fetch just console.logs the different screening times, but we will add additional code to make it render on the different movie pages.